### PR TITLE
 Fix type for OfxParser in Python3

### DIFF
--- a/ofxclient/account.py
+++ b/ofxclient/account.py
@@ -4,10 +4,12 @@ import datetime
 import hashlib
 try:
     # python 3
-    from io import StringIO
+    from io import StringIO, BytesIO
+	IS_PYTHON_2 = False
 except ImportError:
     # python 2
     from StringIO import StringIO
+	IS_PYTHON_2 = True
 import time
 
 from ofxparse import OfxParser, AccountType
@@ -109,7 +111,10 @@ class Account(object):
         :type days: integer
         :rtype: :py:class:`ofxparser.Ofx`
         """
-        return OfxParser.parse(self.download(days=days))
+		if IS_PYTHON_2:
+			return OfxParser.parse(self.download(days=days))
+        else:
+			return OfxParser.parse(BytesIO((((self.download(days=days)).read()).encode())))
 
     def statement(self, days=60):
         """Download the :py:class:`ofxparse.Statement` given the time range

--- a/ofxclient/account.py
+++ b/ofxclient/account.py
@@ -5,11 +5,11 @@ import hashlib
 try:
     # python 3
     from io import StringIO, BytesIO
-	IS_PYTHON_2 = False
+    IS_PYTHON_2 = False
 except ImportError:
     # python 2
     from StringIO import StringIO
-	IS_PYTHON_2 = True
+    IS_PYTHON_2 = True
 import time
 
 from ofxparse import OfxParser, AccountType
@@ -111,10 +111,10 @@ class Account(object):
         :type days: integer
         :rtype: :py:class:`ofxparser.Ofx`
         """
-		if IS_PYTHON_2:
-			return OfxParser.parse(self.download(days=days))
+        if IS_PYTHON_2:
+            return OfxParser.parse(self.download(days=days))
         else:
-			return OfxParser.parse(BytesIO((((self.download(days=days)).read()).encode())))
+            return OfxParser.parse(BytesIO((((self.download(days=days)).read()).encode())))
 
     def statement(self, days=60):
         """Download the :py:class:`ofxparse.Statement` given the time range

--- a/ofxclient/institution.py
+++ b/ofxclient/institution.py
@@ -4,11 +4,11 @@ import hashlib
 try:
     # python 3
     from io import StringIO, BytesIO
-	IS_PYTHON_2 = False
+    IS_PYTHON_2 = False
 except ImportError:
     # python 2
     from StringIO import StringIO
-	IS_PYTHON_2 = Trues
+    IS_PYTHON_2 = Trues
 
 from bs4 import BeautifulSoup
 from ofxparse import OfxParser
@@ -142,10 +142,10 @@ class Institution(object):
         resp = client.post(query)
         resp_handle = StringIO(resp)
 
-		if IS_PYTHON_2:
-			parsed = OfxParser.parse(resp_handle)
-		else:
-			parsed = OfxParser.parse(BytesIO((((resp_handle).read()).encode())))
+        if IS_PYTHON_2:
+            parsed = OfxParser.parse(resp_handle)
+        else:
+            parsed = OfxParser.parse(BytesIO((((resp_handle).read()).encode())))
 
         return [Account.from_ofxparse(a, institution=self)
                 for a in parsed.accounts]

--- a/ofxclient/institution.py
+++ b/ofxclient/institution.py
@@ -3,10 +3,12 @@ from __future__ import unicode_literals
 import hashlib
 try:
     # python 3
-    from io import StringIO
+    from io import StringIO, BytesIO
+	IS_PYTHON_2 = False
 except ImportError:
     # python 2
     from StringIO import StringIO
+	IS_PYTHON_2 = Trues
 
 from bs4 import BeautifulSoup
 from ofxparse import OfxParser
@@ -140,7 +142,10 @@ class Institution(object):
         resp = client.post(query)
         resp_handle = StringIO(resp)
 
-        parsed = OfxParser.parse(resp_handle)
+		if IS_PYTHON_2:
+			parsed = OfxParser.parse(resp_handle)
+		else:
+			parsed = OfxParser.parse(BytesIO((((resp_handle).read()).encode())))
 
         return [Account.from_ofxparse(a, institution=self)
                 for a in parsed.accounts]


### PR DESCRIPTION
OfxParser expects a byte stream object, but the Python3 IO.StringIO
objects is a string. This causes error
"TypeError: Can't convert 'bytes' object to str implicitly"
Converting Python3 IO.StringIO to IO.BytesIO object fixes error.