### PR TITLE
Fix Discover Card 403 by manually ordering HTTP headers

### DIFF
--- a/ofxclient/client.py
+++ b/ofxclient/client.py
@@ -101,11 +101,22 @@ class Client:
         garbage, path = splittype(i.url)
         host, selector = splithost(path)
         h = HTTPSConnection(host, timeout=60)
-        h.request('POST', selector, query,
-                  {
-                      "Content-type": "application/x-ofx",
-                      "Accept": "*/*, application/x-ofx"
-                  })
+        if host == 'ofx.discovercard.com':
+            # Discover requires a particular ordering of headers, so send the
+            # request step by step.
+            h.putrequest('POST', selector, skip_host=True,
+                         skip_accept_encoding=True)
+            h.putheader('Content-Type', 'application/x-ofx')
+            h.putheader('Host', host)
+            h.putheader('Content-Length', len(query))
+            h.putheader('Connection', 'Keep-Alive')
+            h.endheaders(query.encode())
+        else:
+            h.request('POST', selector, query,
+                      {
+                          "Content-type": "application/x-ofx",
+                          "Accept": "*/*, application/x-ofx"
+                      })
         res = h.getresponse()
         response = res.read().decode('ascii', 'ignore')
         logging.debug('---- response ----')


### PR DESCRIPTION
Since mid February Discover Card has been giving 403 Permission Denied for OFX requests that previously worked. It was [discovered on OFX Home Forum](http://www.ofxhome.com/ofxforum/viewtopic.php?pid=108449#p108449) that Discover now requires a particular set of HTTP headers ordered in a particular way. This PR implements the fix.