### PR TITLE
Citi fix and some other fixes - fixes #38

### DIFF
--- a/ofxclient/cli.py
+++ b/ofxclient/cli.py
@@ -22,6 +22,11 @@ DOWNLOAD_DAYS = 30
 GlobalConfig = None
 
 
+FORMAT = "[%(asctime)s %(levelname)s] %(message)s"
+logging.basicConfig(level=logging.DEBUG, format=FORMAT)
+logger = logging.getLogger()
+
+
 def run():
     global GlobalConfig
 
@@ -238,7 +243,7 @@ def client_args_for_bank(bank_info, ofx_version):
     :return: Client arguments for a specific institution
     :rtype: dict
     """
-    client_args = {'ofx_version': ofx_version}
+    client_args = {'ofx_version': str(ofx_version)}
     if 'ofx.discovercard.com' in bank_info['url']:
         # Discover needs no User-Agent and no Accept headers
         client_args['user_agent'] = False

--- a/ofxclient/cli.py
+++ b/ofxclient/cli.py
@@ -163,6 +163,8 @@ def view_account_menu(account, args):
         print("  App Ver:               %s" % client.app_version)
         print("  App Id:                %s" % client.app_id)
         print("  OFX Ver:               %s" % client.ofx_version)
+        print("  User-Agent header:     %s" % client.user_agent)
+        print("  Accept header:         %s" % client.accept)
         print("  Config File:           %s" % GlobalConfig.file_name)
 
         menu_item('D', 'Download')

--- a/ofxclient/cli.py
+++ b/ofxclient/cli.py
@@ -208,7 +208,7 @@ def login_check_menu(bank_info, args):
             description=bank_info['name'],
             username=username,
             password=password,
-            client_args={'ofx_version': args.ofx_version}
+            client_args=client_args_for_bank(bank_info, args.ofx_version)
         )
         try:
             i.authenticate()
@@ -222,6 +222,31 @@ def login_check_menu(bank_info, args):
         GlobalConfig.save()
         return 1
 
+
+def client_args_for_bank(bank_info, ofx_version):
+    """
+    Return the client arguments to use for a particular Institution, as found
+    from ofxhome. This provides us with an extension point to override or
+    augment ofxhome data for specific institutions, such as those that
+    require specific User-Agent headers (or no User-Agent header).
+
+    :param bank_info: OFXHome bank information for the institution, as returned
+      by ``OFXHome.lookup()``
+    :type bank_info: dict
+    :param ofx_version: OFX Version argument specified on command line
+    :type ofx_version: str
+    :return: Client arguments for a specific institution
+    :rtype: dict
+    """
+    client_args = {'ofx_version': ofx_version}
+    if 'ofx.discovercard.com' in bank_info['url']:
+        # Discover needs no User-Agent and no Accept headers
+        client_args['user_agent'] = False
+        client_args['accept'] = False
+    if 'www.accountonline.com' in bank_info['url']:
+        # Citi needs no User-Agent header
+        client_args['user_agent'] = False
+    return client_args
 
 def write_and_handle_download(ofx_data, name):
     outfile = io.open(name, 'w')

--- a/ofxclient/cli.py
+++ b/ofxclient/cli.py
@@ -22,11 +22,6 @@ DOWNLOAD_DAYS = 30
 GlobalConfig = None
 
 
-FORMAT = "[%(asctime)s %(levelname)s] %(message)s"
-logging.basicConfig(level=logging.DEBUG, format=FORMAT)
-logger = logging.getLogger()
-
-
 def run():
     global GlobalConfig
 

--- a/ofxclient/client.py
+++ b/ofxclient/client.py
@@ -19,6 +19,8 @@ import uuid
 DEFAULT_APP_ID = 'QWIN'
 DEFAULT_APP_VERSION = '2500'
 DEFAULT_OFX_VERSION = '102'
+DEFAULT_USER_AGENT = 'httpclient'
+DEFAULT_ACCEPT = '*/*, application/x-ofx'
 
 LINE_ENDING = "\r\n"
 
@@ -40,6 +42,12 @@ class Client:
     :type app_version: string
     :param ofx_version: OFX spec version
     :type ofx_version: string
+    :param user_agent: Value to send for User-Agent HTTP header. Leave as
+      None to send default. Set to False to not send User-Agent header.
+    :type user_agent: str, None or False
+    :param accept: Value to send for Accept HTTP header. Leave as
+      None to send default. Set to False to not send User-Agent header.
+    :type accept: str, None or False
     """
 
     def __init__(
@@ -48,14 +56,38 @@ class Client:
         id=ofx_uid(),
         app_id=DEFAULT_APP_ID,
         app_version=DEFAULT_APP_VERSION,
-        ofx_version=DEFAULT_OFX_VERSION
+        ofx_version=DEFAULT_OFX_VERSION,
+        user_agent=DEFAULT_USER_AGENT,
+        accept=DEFAULT_ACCEPT
     ):
         self.institution = institution
         self.id = id
         self.app_id = app_id
         self.app_version = app_version
         self.ofx_version = ofx_version
+        self.user_agent = user_agent
+        self.accept = accept
+        # used when serializing Institutions
+        self._init_args = {
+            'id': self.id,
+            'app_id': self.app_id,
+            'app_version': self.app_version,
+            'ofx_version': self.ofx_version,
+            'user_agent': self.user_agent,
+            'accept': self.accept
+        }
         self.cookie = 3
+
+    @property
+    def init_args(self):
+        """
+        Return a dict of the arguments used to initialize this client,
+        suitable for use when serializing an Institution.
+
+        :return: constructor arguments
+        :rtype: dict
+        """
+        return self._init_args
 
     def authenticated_query(
         self,

--- a/ofxclient/client.py
+++ b/ofxclient/client.py
@@ -133,23 +133,19 @@ class Client:
         garbage, path = splittype(i.url)
         host, selector = splithost(path)
         h = HTTPSConnection(host, timeout=60)
-        if host == 'ofx.discovercard.com':
-            # Discover requires a particular ordering of headers, so send the
-            # request step by step.
-            h.putrequest('POST', selector, skip_host=True,
-                         skip_accept_encoding=True)
-            h.putheader('Content-Type', 'application/x-ofx')
-            h.putheader('Host', host)
-            h.putheader('Content-Length', len(query))
-            h.putheader('Connection', 'Keep-Alive')
-            h.endheaders(query.encode())
-        else:
-            h.request('POST', selector, query,
-                      {
-                          "Content-type": "application/x-ofx",
-                          "Accept": "*/*, application/x-ofx",
-                          "User-Agent": "httpclient"
-                      })
+        # Discover requires a particular ordering of headers, so send the
+        # request step by step.
+        h.putrequest('POST', selector, skip_host=True,
+                     skip_accept_encoding=True)
+        h.putheader('Content-Type', 'application/x-ofx')
+        h.putheader('Host', host)
+        h.putheader('Content-Length', len(query))
+        h.putheader('Connection', 'Keep-Alive')
+        if self.accept:
+            h.putheader('Accept', self.accet)
+        if self.user_agent:
+            h.putheader('User-Agent', self.user_agent)
+        h.endheaders(query.encode())
         res = h.getresponse()
         response = res.read().decode('ascii', 'ignore')
         logging.debug('---- response ----')

--- a/ofxclient/client.py
+++ b/ofxclient/client.py
@@ -142,7 +142,7 @@ class Client:
         h.putheader('Content-Length', len(query))
         h.putheader('Connection', 'Keep-Alive')
         if self.accept:
-            h.putheader('Accept', self.accet)
+            h.putheader('Accept', self.accept)
         if self.user_agent:
             h.putheader('User-Agent', self.user_agent)
         h.endheaders(query.encode())

--- a/ofxclient/config.py
+++ b/ofxclient/config.py
@@ -118,9 +118,6 @@ class SecurableConfigParser(ConfigParser):
     def set(self, section, option, value):
         """Set an option value. Knows how to set options properly marked
         as secure."""
-        print("set [%s] %s to: %s (%s)" % (
-            section, option, value, type(value)
-        ))
         if value is False:
             value = '!!False!!'
         if self.is_secure_option(section, option):

--- a/ofxclient/config.py
+++ b/ofxclient/config.py
@@ -100,6 +100,8 @@ class SecurableConfigParser(ConfigParser):
         for k, v in ConfigParser.items(self, section):
             if self.is_secure_option(section, k):
                 v = self.get(section, k)
+            if v == '!!False!!':
+                v = False
             items.append((k, v))
         return items
 
@@ -116,6 +118,11 @@ class SecurableConfigParser(ConfigParser):
     def set(self, section, option, value):
         """Set an option value. Knows how to set options properly marked
         as secure."""
+        print("set [%s] %s to: %s (%s)" % (
+            section, option, value, type(value)
+        ))
+        if value is False:
+            value = '!!False!!'
         if self.is_secure_option(section, option):
             self.set_secure(section, option, value)
         else:
@@ -139,10 +146,14 @@ class SecurableConfigParser(ConfigParser):
         if self.is_secure_option(section, option) and self.keyring_available:
             s_option = "%s%s" % (section, option)
             if self._unsaved.get(s_option, [''])[0] == 'set':
-                return self._unsaved[s_option][1]
+                res = self._unsaved[s_option][1]
             else:
-                return keyring.get_password(self.keyring_name, s_option)
-        return ConfigParser.get(self, section, option, *args)
+                res = keyring.get_password(self.keyring_name, s_option)
+        else:
+            res = ConfigParser.get(self, section, option, *args)
+        if res == '!!False!!':
+            return False
+        return res
 
     def remove_option(self, section, option):
         """Removes the option from ConfigParser as well as

--- a/ofxclient/institution.py
+++ b/ofxclient/institution.py
@@ -113,7 +113,7 @@ class Institution(object):
             u = username
             p = password
 
-        client = self.client(**self.client_args)
+        client = self.client()
         query = client.authenticated_query(username=u, password=p)
         res = client.post(query)
         ofx = BeautifulSoup(res, 'lxml')

--- a/ofxclient/institution.py
+++ b/ofxclient/institution.py
@@ -165,22 +165,14 @@ class Institution(object):
             'password':    'Customer password',
             'description': 'descr',
             'client_args': {
-                'id':          'random client id - see Client() for default',
-                'app_id':      'app name - see Client() for default',
-                'app_version': 'app version - see Client() for default',
-                'ofx_version': 'ofx version - see Client() for default',
+                'id':     'random client id - see Client() for default',
+                'app_id': 'app name - see Client() for default',
+                '...':    'see Client() for other options'
             }
           }
 
         :rtype: nested dictionary
         """
-        client = self.client()
-        client_args = {
-            'id': client.id,
-            'app_id': client.app_id,
-            'app_version': client.app_version,
-            'ofx_version': client.ofx_version,
-        }
         return {
             'id': self.id,
             'org': self.org,
@@ -189,7 +181,7 @@ class Institution(object):
             'username': self.username,
             'password': self.password,
             'description': self.description,
-            'client_args': client_args,
+            'client_args': self.client().init_args,
             'local_id': self.local_id()
         }
 

--- a/ofxclient/institution.py
+++ b/ofxclient/institution.py
@@ -113,7 +113,7 @@ class Institution(object):
             u = username
             p = password
 
-        client = self.client()
+        client = self.client(**self.client_args)
         query = client.authenticated_query(username=u, password=p)
         res = client.post(query)
         ofx = BeautifulSoup(res, 'lxml')


### PR DESCRIPTION
I was hit by #38, Citi Credit Cards not working, like the other people who commented there. It turns out that, after trying a bunch of things and doing some investigation online, Citi is sensitive to the User-Agent header. If I totally omit it, things work right.

I did a bit of a refactor here. Previously (from [this commit](https://github.com/captin411/ofxclient/commit/11701502d6bd056ec9224d5fe1a6bfbcc1ddc39e)), ``client.py`` itself had a separate branch for Discover, which omitted the ``Accept`` and ``User-Agent`` headers and ensured the headers were ordered correctly for Discover.

I've removed the alternate code path and made this logic a bit more configurable... ``Client()`` now takes two additional arguments on the constructor, ``user_agent`` and ``accept``, corresponding to those HTTP headers. They can either be set to None (use the default values, as previously), a specific string, or False in which case the header will be omitted completely. I also did a bit of work to make serializing the Client arguments a bit easier.

To expose this to the user, I added a ``client_args_for_bank()`` function to ``cli.py``. When we fetch data for a bank from ofxhome and then instantiate an Institution for it, instead of passing a hard-coded dict of client_args (which just contained ``ofx_version``), this method builds the client args. It provides one simple place for us to define institution-specific client arguments. In addition, instead of being hard-coded into Client directly these will be serialized as part of the config... so things should work right all the way from the CLI for institutions that we've explicitly set args for, _but_ if problems arise users can add or alter the client args in their ``ofxclient.ini`` without having to dig into the Python.

The one down side of this is that, while it's probably more robust in the long run, it means that existing Discover accounts will need a manual update to ``ofxclient.ini`` to get them working again, specifically:

```
institution.client_args.user_agent = !!False!!
institution.client_args.accept = !!False!!
```

To get previously-working Citi accounts working again, use only the ``user_agent`` line above.

Note that this also included some changes to SecurableConfigParser to set and get boolean False values.