### PR TITLE
Fixes #46 - Vanguard fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,4 +12,5 @@ mattprompt - python 3 fixes
 ridler77 - bug fixes
 gboudreau - TD Bank fix
 fanqiuwen - Discover card fix
+jantman - Additional Discover fix, Vanguard cookie fix
 Everyone who uses this - I'm honored that you find this hobby project useful


### PR DESCRIPTION
Fixes #46 - Vanguard download problems

This provides a fix for the Vanguard downloading problems. It *may* also fix other banks that decide to follow the same pattern...

I found that [PocketSense](https://pocketsense.blogspot.com/2017/03/new-version-released.html?showComment=1501423318457#c1181103133737423582) users were having the same problem with Vanguard. That application's developer determined that Vanguard now requires cookie handling; the original request to Vanguard returns a HTTP 200 with a 0-length body, but a number of ``Set-Cookie`` headers. Re-sending the request with the appropriate ``Cookie`` headers returns the proper OFX.

This PR includes:

1. Minor refactor to the HTTP header sending logic in ``Client.post()`` so it builds a list of headers and then puts them all at once, logging the headers as it does. Previously, the request body (query) was logged at debug level but the headers were not, and headers appear to be more problematic lately.
2. Rename the ``Client.post()`` method to ``Client._do_post()`` and create a new ``Client.post()`` wrapper method. This wrapper calls ``.post()`` and if (and only if) the response has 0 length, an HTTP 200 return code, and one or more ``Set-Cookie`` headers present, it retries the request with the proper Cookie header set and returns _that_ response.

I've tested this just now and it works properly to fix the Vanguard problem, and also works with American Express, Citi Cards, Discover and TIAA-CREF.