### PR TITLE
Updated conditional test for value being passed into ConfigParser

### DIFF
--- a/ofxclient/config.py
+++ b/ofxclient/config.py
@@ -123,7 +123,7 @@ class SecurableConfigParser(ConfigParser):
         if self.is_secure_option(section, option):
             self.set_secure(section, option, value)
         else:
-            ConfigParser.set(self, section, option, value)
+            ConfigParser.set(self, section, option, str(value))
 
     def set_secure(self, section, option, value):
         """Set an option and mark it as secure.

--- a/ofxclient/config.py
+++ b/ofxclient/config.py
@@ -118,12 +118,13 @@ class SecurableConfigParser(ConfigParser):
     def set(self, section, option, value):
         """Set an option value. Knows how to set options properly marked
         as secure."""
-        if value is False:
+        if not value:
             value = '!!False!!'
+#        section, option, value = (str(section), str(option), str(value))
         if self.is_secure_option(section, option):
             self.set_secure(section, option, value)
         else:
-            ConfigParser.set(self, section, option, str(value))
+            ConfigParser.set(self, section, option, value)
 
     def set_secure(self, section, option, value):
         """Set an option and mark it as secure.
@@ -131,6 +132,7 @@ class SecurableConfigParser(ConfigParser):
         Any subsequent uses of 'set' or 'get' will also
         now know that this option is secure as well.
         """
+#        section, option, value = (str(section), str(option), str(value))
         if self.keyring_available:
             s_option = "%s%s" % (section, option)
             self._unsaved[s_option] = ('set', value)

--- a/ofxclient/config.py
+++ b/ofxclient/config.py
@@ -120,7 +120,6 @@ class SecurableConfigParser(ConfigParser):
         as secure."""
         if not value:
             value = '!!False!!'
-#        section, option, value = (str(section), str(option), str(value))
         if self.is_secure_option(section, option):
             self.set_secure(section, option, value)
         else:
@@ -132,7 +131,6 @@ class SecurableConfigParser(ConfigParser):
         Any subsequent uses of 'set' or 'get' will also
         now know that this option is secure as well.
         """
-#        section, option, value = (str(section), str(option), str(value))
         if self.keyring_available:
             s_option = "%s%s" % (section, option)
             self._unsaved[s_option] = ('set', value)


### PR DESCRIPTION
Update to the "set" method for the "SecurableConfigParser" class passes null values to ConfigParser as "!!False!!".

This update fixes a crash from ConfigParser due to a type error. See issue "Crash from configparser #31 "

```
+----------------------------------
Main
Edit /home/chris/ofxclient.ini to
change descriptions or ofx options
+----------------------------------
(A) Add an account
(Q) Quit
choice> a
+----------------------------------
Add account
+----------------------------------
------
Notice
------
You are about to search for bank connection information
on a third party website.  This means you are trusting
http://ofxhome.com and their security policies.

You will be sending your bank name to this website.
------
bank name eg. "express" (enter to exit)> fifth third
(0) Fifth Third Bancorp
choice> 0
------
Notice
------
You are about to test to make sure your username and password
are correct.  This means you will be sending it to the URL below.
If the URL does not appear to belong to your bank then you should
exit this program by hitting CTRL-C.
  bank name: Fifth Third Bancorp
  bank url:  https://banking.53.com/ofx/OFXServlet
------
username> ****************                                                               
password> 
Traceback (most recent call last):
  File "/usr/bin/ofxclient", line 11, in <module>
    sys.exit(run())
  File "/usr/lib/python3.5/site-packages/ofxclient/cli.py", line 63, in run
    main_menu(args)
  File "/usr/lib/python3.5/site-packages/ofxclient/cli.py", line 83, in main_menu
    add_account_menu(args)
  File "/usr/lib/python3.5/site-packages/ofxclient/cli.py", line 130, in add_account_menu
    if login_check_menu(bank, args):
  File "/usr/lib/python3.5/site-packages/ofxclient/cli.py", line 219, in login_check_menu
    GlobalConfig.add_account(a)
  File "/usr/lib/python3.5/site-packages/ofxclient/config.py", line 244, in add_account
    self.parser.set(section_id, key, section_items[key])
  File "/usr/lib/python3.5/site-packages/ofxclient/config.py", line 122, in set
    ConfigParser.set(self, section, option, value)
  File "/usr/lib64/python3.5/configparser.py", line 1189, in set
    self._validate_value_types(option=option, value=value)
  File "/usr/lib64/python3.5/configparser.py", line 1174, in _validate_value_types
    raise TypeError("option values must be strings")
TypeError: option values must be strings
```
