### PR TITLE
Added an encode call so ofxclient -d file.ofx would actually work in …

### DIFF
--- a/ofxclient/cli.py
+++ b/ofxclient/cli.py
@@ -53,7 +53,7 @@ def run():
                 ofxdata = a.download(days=args.download_days)
             else:
                 ofxdata = combined_download(accounts, days=args.download_days)
-            args.download.write(ofxdata.read())
+            args.download.write(ofxdata.read().encode())
             if args.open:
                 open_with_ofx_handler(args.download.name)
             sys.exit(0)


### PR DESCRIPTION
…python3

The problems is the -d filehandle is opened in 'wb' so in python3 the written type needs to be a bytes object.