### PR TITLE
Allow specifying both start and end date for transaction downloads

### DIFF
--- a/ofxclient/client.py
+++ b/ofxclient/client.py
@@ -108,10 +108,10 @@ class Client:
             contents.append(with_message)
         return LINE_ENDING.join([self.header(), _tag(*contents)])
 
-    def bank_account_query(self, number, date, account_type, bank_id):
+    def bank_account_query(self, number, date_start, date_end, account_type, bank_id):
         """Bank account statement request"""
         return self.authenticated_query(
-            self._bareq(number, date, account_type, bank_id)
+            self._bareq(number, date_start, date_end, account_type, bank_id)
         )
 
     def credit_card_account_query(self, number, date):
@@ -236,7 +236,7 @@ class Client:
         return self._message("SIGNUP", "ACCTINFO", req)
 
 # this is from _ccreq below and reading page 176 of the latest OFX doc.
-    def _bareq(self, acctid, dtstart, accttype, bankid):
+    def _bareq(self, acctid, dtstart, dtend, accttype, bankid):
         req = _tag("STMTRQ",
                    _tag("BANKACCTFROM",
                         _field("BANKID", bankid),
@@ -244,6 +244,7 @@ class Client:
                         _field("ACCTTYPE", accttype)),
                    _tag("INCTRAN",
                         _field("DTSTART", dtstart),
+                        _field("DTEND", dtend),
                         _field("INCLUDE", "Y")))
         return self._message("BANK", "STMT", req)
 


### PR DESCRIPTION
Allow specifying both start and end date for transaction downloads, making it possible to collect transactions between Y days before X and X.

---

I'm not super familiar with GitHub (I usually develop for Drupal) and I think this is my first PR, so I hope I'm following the correct procecure. This is related to [Allow specifying both start and end date for transaction downloads](https://github.com/captin411/ofxclient/issues/42).

The way I've solved this is by adding an additional end date argument to Account::transactions() and various methods it calls. The API is a little weird (since you specify the days before followed by the end date rather than start and end date) but it should be backwards compatible with old code.

I'm not sure if this is 100% ready to be merged in or if the tests should be updated first. Haven't figured out how to run them yet (not super familiar with Python either).

I've been running this fix since I think October of 2018 and it works for my purposes at least. Code looks something like this:

```python
def retrieve_transactions(month_start: datetime, month_end: datetime, last_month_start: datetime, next_month_start: datetime):
    tangerine_cc = OfxConfig().account('OMITTED')
    tangerine_cc_trans_1 = tangerine_cc.transactions(30, last_month_start)
    tangerine_cc_trans_2 = tangerine_cc.transactions(30, month_start)
    tangerine_cc_trans_3 = tangerine_cc.transactions(30, next_month_start)

    tangerine_cc_trans = tangerine_cc_trans_1 + tangerine_cc_trans_2 + tangerine_cc_trans_3
    tangerine_cc_trans = list(filter(
        lambda x: month_start < x.date < month_end,
        tangerine_cc_trans
    ))
    tangerine_cc_trans.sort(key=lambda x: x.date)
    return tangerine_cc_trans
```