### PR TITLE
Retry with TSLv1 if connection errors with unsupported protocol

### DIFF
--- a/ofxclient/client.py
+++ b/ofxclient/client.py
@@ -15,6 +15,7 @@ except ImportError:
     # python 2
     from urllib import splittype, splithost
 import uuid
+import ssl
 
 DEFAULT_APP_ID = 'QWIN'
 DEFAULT_APP_VERSION = '2500'
@@ -154,7 +155,15 @@ class Client:
         logging.debug('posting data to %s' % i.url)
         garbage, path = splittype(i.url)
         host, selector = splithost(path)
-        h = HTTPSConnection(host, timeout=60)
+        try:
+            h = HTTPSConnection(host, timeout=60)
+            h.connect()
+        except ssl.SSLError as ex:
+            if (ex.reason == "UNSUPPORTED_PROTOCOL"):
+                h = HTTPSConnection(host, timeout=60, context=ssl.SSLContext(ssl.PROTOCOL_TLSv1))
+                h.connect()
+            else:
+                raise
         # Discover requires a particular ordering of headers, so send the
         # request step by step.
         h.putrequest('POST', selector, skip_host=True,


### PR DESCRIPTION
This is a fix for https://github.com/captin411/ofxclient/issues/48. It simply retries a connection with TLSv1 if there is an error when connecting.