### PR TITLE
lock keyring version to 8.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='ofxclient',
       },
       install_requires=[
           "argparse",
-          "keyring",
+          "keyring==8.4.1",
           "lxml",
           "ofxhome",
           "ofxparse>0.8",


### PR DESCRIPTION
The most recent versions of keyring remove support for Python 2.  We
need to lock the keyring version to one that still supports Python 2.
I've chosen 8.4.1 because that's the version specified in the
requirements.txt