### PR TITLE
deduplicate requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,1 @@
-argparse==1.4.1; python_version < '2.7'
-beautifulsoup4==4.4.1
-keyring==8.4.1
-ofxhome==0.3.3
-ofxparse==0.14
-lxml>=3.5.0
-keyrings.alt==1.1.1
-pycrypto==2.6.1
+.

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,14 @@ setup(name='ofxclient',
           ]
       },
       install_requires=[
-          "argparse",
-          "keyring",
-          "lxml",
-          "ofxhome",
-          "ofxparse>0.8",
-          "beautifulsoup4",
+          "argparse==1.4.1; python_version < '2.7'",
+          "keyring==8.4.1",
+          "lxml>=3.5.0",
+          "ofxhome==0.3.3",
+          "ofxparse==0.14",
+          "beautifulsoup4==4.4.1",
+          "keyrings.alt==1.1.1",
+          "pycrypto==2.6.1"
       ],
       test_suite='tests',
       )


### PR DESCRIPTION
Move all requirements into setup.py and have requirements.txt reference
that.  That way we don't have the requirements in 2 different places.