### PR TITLE
Schwab requires no User-Agent header

### DIFF
--- a/ofxclient/cli.py
+++ b/ofxclient/cli.py
@@ -246,6 +246,9 @@ def client_args_for_bank(bank_info, ofx_version):
     if 'www.accountonline.com' in bank_info['url']:
         # Citi needs no User-Agent header
         client_args['user_agent'] = False
+    if 'ofx.schwab.com' in bank_info['url']:
+        # Schwab requires no User-Agent header
+        client_args['user_agent'] = False
     return client_args
 
 def write_and_handle_download(ofx_data, name):


### PR DESCRIPTION
Sometime within the last month, Schwab started requiring no User-Agent header. If I request with User-Agent, the request times out every time. Without User-Agent, it works.