### PR TITLE
Fix header requirements for Schwab (bank and brokerage) in cli.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.0.5] - XXXX-XX-XX
+- Fix Schwab header requirements
+
 ## [2.0.4] - 2019-02-10
 - fix a number of python3 encoding issues
 - fix bug with ConfigParser

--- a/ofxclient/cli.py
+++ b/ofxclient/cli.py
@@ -246,7 +246,7 @@ def client_args_for_bank(bank_info, ofx_version):
     if 'www.accountonline.com' in bank_info['url']:
         # Citi needs no User-Agent header
         client_args['user_agent'] = False
-    if 'ofx.schwab.com' in bank_info['url']
+    if 'ofx.schwab.com' in bank_info['url']:
         # Schwab needs just "application/x-ofx" in the accept header
         # and no User-Agent header
         client_args['accept'] = "application/x-ofx"

--- a/ofxclient/cli.py
+++ b/ofxclient/cli.py
@@ -246,6 +246,11 @@ def client_args_for_bank(bank_info, ofx_version):
     if 'www.accountonline.com' in bank_info['url']:
         # Citi needs no User-Agent header
         client_args['user_agent'] = False
+    if 'ofx.schwab.com' in bank_info['url']
+        # Schwab needs just "application/x-ofx" in the accept header
+        # and no User-Agent header
+        client_args['accept'] = "application/x-ofx"
+        client_args['user_agent'] = False
     return client_args
 
 def write_and_handle_download(ofx_data, name):


### PR DESCRIPTION
This adds `client_args` overrides for Schwab bank and brokerage, to send the expected `Accept` header and no `User-Agent` header. Prior to this fix, Schwab's OFX servers would be unresponsive to requests made by ofxclient > 2.0.2